### PR TITLE
Updates for Manticore dev version

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Evaluating Manticore Search:
 docker pull manticoresearch/manticore
 docker run -p 9306:9306 -p 9308:9308 manticoresearch/manticore
 ```
-- For Manticore dev version
+- For Manticore dev version (MS dev)
 ```shell
 docker pull manticoresearch/manticore:dev
 docker run -p 9306:9306 -p 9308:9308 manticoresearch/manticore:dev

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Evaluating Manticore Search:
 docker pull manticoresearch/manticore
 docker run -p 9306:9306 -p 9308:9308 manticoresearch/manticore
 ```
+- For Manticore dev version
+```shell
+docker pull manticoresearch/manticore:dev
+docker run -p 9306:9306 -p 9308:9308 manticoresearch/manticore:dev
+```
 
 2. Create and populate indices:
 
@@ -167,6 +172,7 @@ Results for trec-covid:
 |---------------:|:----------------------|------------:|
 |     trec-covid | MS (default)          |     0.29494 |
 | **trec-covid** | **MS (es-like)**      | **0.59764** |
+| **trec-covid** | **MS dev (es-like)**         | **0.71211** |
 | **trec-covid** | **ES**                | **0.68803** |
 |     trec-covid | ES (reported in BEIR) |       0.616 |
 
@@ -176,6 +182,7 @@ Results for nfcorpus:
 |-----------:|:----------------------|--------:|
 |   nfcorpus | MS (default)          | 0.28791 |
 |   **nfcorpus** | **MS (es-like)**          | **0.31715** |
+|   **nfcorpus** | **MS dev (es-like)**          | **0.34537** |
 |   **nfcorpus** | **ES**                    | **0.34281** |
 |   nfcorpus | ES (reported in BEIR) |   0.297 |
 

--- a/benchmark/manticore/prepare.py
+++ b/benchmark/manticore/prepare.py
@@ -79,6 +79,15 @@ def prepare(data_file: str,
             except ApiException as e:
                 msg.fail("Exception when calling IndexApi->insert: %s\n" % e)
 
+        # Optimize index to prevent possible IDF miscalculation
+        api_instance = manticoresearch.UtilsApi(api_client)
+        body = "FLUSH RAMCHUNK {}".format(index_name)
+        api_instance.sql(body, raw_response=raw_response)
+        # Give time to Manticore for flush completing
+        time.sleep(5)
+        body = "OPTIMIZE INDEX {} OPTION cutoff=1, sync=1".format(index_name)
+        api_instance.sql(body, raw_response=raw_response)
+
         msg.info("Documents inserted in {}s".format(time.time() - start_time))
 
 


### PR DESCRIPTION
Following [this](https://forum.manticoresearch.com/t/comparing-information-retrieval-metrics-with-bm25-for-manticore-search-vs-elasticsearch/1001) discussion, we have added results retrieved through the updated Manticore tf-idf implementation to the summary table.

A few notes:
- in case of indexes having multiple chunks, IDF miscalculation can take place, which we have handled by adding the `OPTIMIZE INDEX` command after all the documents are inserted
- `SUM` function is not needed in ranker expressions with a bm25 ranker so we have removed it from there
- since a new Manticore Python client version is not available through the pip repository yet, we have set `raw_response=False` mode in the code to provide a compatibility with the Manticore dev version and adjusted the handling of responses accordingly
- before calculating metrics, we have filtered out queries with empty results from the response data as Elastic does, otherwise it would cause discrepancies in further evaluations